### PR TITLE
Standardise tool name

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@
 [![Codestyle: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 
-The source code for the Lipid Trafficking Analysis command line interface.
+The source code for the Lipid Traffic Analysis command line interface.
 
 While you are here,
 we'd kindly ask you to abide by our [code of conduct](./coc.md).

--- a/lta/__init__.py
+++ b/lta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""LTA: A Python CLI for Lipid Trafficking Analysis.
+"""LTA: A Python CLI for Lipid Traffic Analysis.
 
 Attributes
 ----------

--- a/lta/helpers/pipeline.py
+++ b/lta/helpers/pipeline.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class Pipeline:
-    """The Lipid Trafficking Analysis pipeline.
+    """The Lipid Traffic Analysis pipeline.
 
     Attributes
     ----------

--- a/lta/parser.py
+++ b/lta/parser.py
@@ -58,7 +58,7 @@ from lta.helpers.custom_types import FloatRange
 
 lta_parser = configargparse.ArgumentParser(
     prog="lta",
-    description="Lipid Trafficking Analysis",
+    description="Lipid Traffic Analysis",
     allow_abbrev=False,
     add_config_file_help=True,
     default_config_files=["lta_conf.txt"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "LipidTA"
 version = "0.12.3"
 packages=[{include = "lta"}]
-description = "Lipid Trafficking Analysis"
+description = "Lipid Traffic Analysis"
 license = "MIT"
 authors = ["rbpatt2019 <rb.patterson.cross@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Previously, Trafficking and Taffic had been used in the name of the software interchangeably. To standardise and avoid confusion, this has been unified to Traffic in all cases.
