### PR TITLE
fix(pipeline.py): exclude control condition

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Cache Nox
         uses: actions/cache@v2
         env:
-          CACHE_NUMBER: 0
+          CACHE_NUMBER: 1
         with:
           path: .nox
           key:

--- a/lta/helpers/pipeline.py
+++ b/lta/helpers/pipeline.py
@@ -381,6 +381,7 @@ class Pipeline:
             for df in self.filtered.values()
         ]
         conditions = [val for mode in conditions for val in mode]
+        conditions = [val for val in conditions if val != control]
 
         for group in conditions:
             self.enfc = self._calculate_enfc((group, control))


### PR DESCRIPTION
Exclude control condition to ensure that a control vs control group is not calculated. Previous implementation took all groups, resulting in a non-sensical control vs control fold change.

Closes #19.
